### PR TITLE
fix: Replace deprecated splat expression with [*] for Terraform 1.5.6

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -26,8 +26,8 @@ module "documentdb_cluster" {
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
 
   db_port         = var.db_port
-  master_username = join("", aws_ssm_parameter.master_username.*.value)
-  master_password = join("", aws_ssm_parameter.master_password.*.value)
+  master_username = join("", aws_ssm_parameter.master_username[*].value)
+  master_password = join("", aws_ssm_parameter.master_password[*].value)
 
   vpc_id                  = module.vpc.outputs.vpc_id
   subnet_ids              = module.vpc.outputs.private_subnet_ids

--- a/src/ssm.tf
+++ b/src/ssm.tf
@@ -28,5 +28,5 @@ resource "aws_ssm_parameter" "master_password" {
 
   name  = "/${module.this.name}/master_password"
   type  = "SecureString"
-  value = join("", random_password.master_password.*.result)
+  value = join("", random_password.master_password[*].result)
 }


### PR DESCRIPTION
## Terraform 0.12.0+ Splat Operator Updates
## What
Updated Terraform configuration to replace legacy splat syntax 

> (resource.*.attribute)

 with modern bracket-based expressions` (resource[*].attribute).`
Incorporated for expressions where applicable to improve flexibility and readability.
No functional changes to infrastructure; these updates are syntax improvements.
## Why
Aligns with Terraform 0.12.0+ enhancements and first-class expression support.
Improves readability and maintainability of Terraform code.
Prevents potential deprecation warnings by replacing outdated syntax.
## References
[Terraform v0.12.0 Upgrade Guide](https://developer.hashicorp.com/terraform/language/v1.2.x/expressions/splat)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Terraform syntax for accessing resource attributes in DocumentDB cluster configuration
	- Modernized SSM parameter value retrieval method for master password

<!-- end of auto-generated comment: release notes by coderabbit.ai -->