### PR TITLE
feat: add performance insights variable

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -26,10 +26,9 @@ module "documentdb_cluster" {
   apply_immediately          = var.apply_immediately
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
 
-  db_port                     = var.db_port
-  master_username             = one(aws_ssm_parameter.master_username[*].value)
-  master_password             = one(aws_ssm_parameter.master_password[*].value)
-  manage_master_user_password = var.manage_master_user_password
+  db_port         = var.db_port
+  master_username = one(aws_ssm_parameter.master_username[*].value)
+  master_password = one(aws_ssm_parameter.master_password[*].value)
 
   vpc_id                  = module.vpc.outputs.vpc_id
   subnet_ids              = module.vpc.outputs.private_subnet_ids

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.26.2"
+  version = "0.16.0"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/main.tf
+++ b/src/main.tf
@@ -27,8 +27,8 @@ module "documentdb_cluster" {
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
 
   db_port                     = var.db_port
-  master_username             = join("", aws_ssm_parameter.master_username[*].value)
-  master_password             = join("", aws_ssm_parameter.master_password[*].value)
+  master_username             = one(aws_ssm_parameter.master_username[*].value)
+  master_password             = one(aws_ssm_parameter.master_password[*].value)
   manage_master_user_password = var.manage_master_user_password
 
   vpc_id                  = module.vpc.outputs.vpc_id

--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.16.0"
+  version = "0.30.0"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.26.3"
+  version = "0.27.0"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,5 +1,6 @@
 locals {
-  enabled = module.this.enabled
+  enabled         = module.this.enabled
+  create_password = local.enabled && var.master_password != null && var.master_password != "" ? 1 : 0
 }
 
 module "documentdb_cluster" {
@@ -28,7 +29,7 @@ module "documentdb_cluster" {
 
   db_port         = var.db_port
   master_username = var.master_username
-  master_password = one(random_password.master_password[*].result)
+  master_password = local.create_password ? one(random_password.master_password[*].result) : var.master_password
 
   vpc_id                  = module.vpc.outputs.vpc_id
   subnet_ids              = module.vpc.outputs.private_subnet_ids

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.27.0"
+  version = "0.30.1"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size
@@ -26,9 +26,10 @@ module "documentdb_cluster" {
   apply_immediately          = var.apply_immediately
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
 
-  db_port         = var.db_port
-  master_username = join("", aws_ssm_parameter.master_username[*].value)
-  master_password = join("", aws_ssm_parameter.master_password[*].value)
+  db_port                     = var.db_port
+  master_username             = join("", aws_ssm_parameter.master_username[*].value)
+  master_password             = join("", aws_ssm_parameter.master_password[*].value)
+  manage_master_user_password = var.manage_master_user_password
 
   vpc_id                  = module.vpc.outputs.vpc_id
   subnet_ids              = module.vpc.outputs.private_subnet_ids

--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.30.0"
+  version = "0.27.0"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled         = module.this.enabled
-  create_password = local.enabled && var.master_password != null && var.master_password != "" ? 1 : 0
+  create_password = local.enabled && var.master_password != null && var.master_password != ""
 }
 
 module "documentdb_cluster" {

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.26.2"
+  version = "0.26.3"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.27.0"
+  version = "0.16.0"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.14.0"
+  version = "0.16.0"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.16.0"
+  version = "0.26.2"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/main.tf
+++ b/src/main.tf
@@ -27,8 +27,8 @@ module "documentdb_cluster" {
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
 
   db_port         = var.db_port
-  master_username = one(aws_ssm_parameter.master_username[*].value)
-  master_password = one(aws_ssm_parameter.master_password[*].value)
+  master_username = var.master_username
+  master_password = one(random_password.master_password[*].result)
 
   vpc_id                  = module.vpc.outputs.vpc_id
   subnet_ids              = module.vpc.outputs.private_subnet_ids

--- a/src/main.tf
+++ b/src/main.tf
@@ -14,6 +14,7 @@ module "documentdb_cluster" {
   engine_version                  = var.engine_version
   deletion_protection             = var.deletion_protection_enabled
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+  enable_performance_insights     = var.enable_performance_insights
   storage_encrypted               = var.encryption_enabled
 
   snapshot_identifier          = var.snapshot_identifier

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled         = module.this.enabled
-  create_password = local.enabled && var.master_password != null && var.master_password != ""
+  create_password = local.enabled && (var.master_password == null || var.master_password == "")
 }
 
 module "documentdb_cluster" {

--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "documentdb_cluster" {
   source  = "cloudposse/documentdb-cluster/aws"
-  version = "0.30.1"
+  version = "0.30.0"
 
   instance_class                  = var.instance_class
   cluster_size                    = var.cluster_size

--- a/src/ssm.tf
+++ b/src/ssm.tf
@@ -28,5 +28,5 @@ resource "aws_ssm_parameter" "master_password" {
 
   name  = "/${module.this.name}/master_password"
   type  = "SecureString"
-  value = join("", random_password.master_password[*].result)
+  value = one(random_password.master_password[*].result)
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -34,16 +34,6 @@ variable "master_username" {
   description = "(Required unless a snapshot_identifier is provided) Username for the master DB user"
 }
 
-variable "manage_master_user_password" {
-  type        = bool
-  description = "Whether to manage the master user password using AWS Secrets Manager."
-  default     = null
-  validation {
-    condition     = var.manage_master_user_password == null || var.manage_master_user_password == true
-    error_message = "Error: `manage_master_user_password` must be set to `true` or `null`"
-  }
-}
-
 variable "retention_period" {
   type        = number
   default     = 5

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -34,6 +34,16 @@ variable "master_username" {
   description = "(Required unless a snapshot_identifier is provided) Username for the master DB user"
 }
 
+variable "manage_master_user_password" {
+  type        = bool
+  description = "Whether to manage the master user password using AWS Secrets Manager."
+  default     = null
+  validation {
+    condition     = var.manage_master_user_password == null || var.manage_master_user_password == true
+    error_message = "Error: `manage_master_user_password` must be set to `true` or `null`"
+  }
+}
+
 variable "retention_period" {
   type        = number
   default     = 5

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -34,6 +34,12 @@ variable "master_username" {
   description = "(Required unless a snapshot_identifier is provided) Username for the master DB user"
 }
 
+variable "master_password" {
+  type        = string
+  default     = null
+  description = "(Required unless a snapshot_identifier is provided) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the DocumentDB Naming Constraints"
+}
+
 variable "retention_period" {
   type        = number
   default     = 5

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -116,6 +116,12 @@ variable "enabled_cloudwatch_logs_exports" {
   default     = []
 }
 
+variable "enable_performance_insights" {
+  type        = bool
+  description = "Specifies whether to enable Performance Insights for the DB Instance."
+  default     = false
+}
+
 variable "eks_security_group_ingress_enabled" {
   type        = bool
   description = "Whether to add the Security Group managed by the EKS cluster in the same regional stack to the ingress allowlist of the DocumentDB cluster."

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -25,12 +25,10 @@ func (s *ComponentSuite) TestBasic() {
 	const awsRegion = "us-east-2"
 
 	name := strings.ToLower(random.UniqueId())
-	password := random.UniqueId()
 	userName := "test_user"
 
 	inputs := map[string]any{
 		"master_username": userName,
-		"master_password": password,
 		"name":            fmt.Sprintf("%s-docdb", name),
 	}
 

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -25,7 +25,7 @@ func (s *ComponentSuite) TestBasic() {
 	const awsRegion = "us-east-2"
 
 	name := strings.ToLower(random.UniqueId())
-	password := random.UniqueId()
+	password := random.UniqueId() + random.UniqueId()[:4] // Combine two IDs to ensure at least 8 characters
 	userName := "test_user"
 
 	inputs := map[string]any{

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -25,10 +25,12 @@ func (s *ComponentSuite) TestBasic() {
 	const awsRegion = "us-east-2"
 
 	name := strings.ToLower(random.UniqueId())
+	password := random.UniqueId()
 	userName := "test_user"
 
 	inputs := map[string]any{
 		"master_username": userName,
+		"master_password": password,
 		"name":            fmt.Sprintf("%s-docdb", name),
 	}
 

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -91,7 +91,17 @@ func (s *ComponentSuite) TestEnabledFlag() {
 	const stack = "default-test"
 	const awsRegion = "us-east-2"
 
-	s.VerifyEnabledFlag(component, stack, nil)
+	name := strings.ToLower(random.UniqueId())
+	password := random.UniqueId() + random.UniqueId()[:4] // Combine two IDs to ensure at least 8 characters
+	userName := "test_user"
+
+	inputs := map[string]any{
+		"master_username": userName,
+		"master_password": password,
+		"name":            fmt.Sprintf("%s-docdb", name),
+	}
+
+	s.VerifyEnabledFlag(component, stack, &inputs)
 }
 
 func TestRunSuite(t *testing.T) {

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -19,19 +19,21 @@ type ComponentSuite struct {
 	helper.TestSuite
 }
 
+var (
+	suffix   = strings.ToLower(random.UniqueId())
+	userName = "test_user"
+	password = random.UniqueId() + random.UniqueId()[:4] // Combine two IDs to ensure at least 8 characters
+)
+
 func (s *ComponentSuite) TestBasic() {
 	const component = "documentdb/basic"
 	const stack = "default-test"
 	const awsRegion = "us-east-2"
 
-	name := strings.ToLower(random.UniqueId())
-	password := random.UniqueId() + random.UniqueId()[:4] // Combine two IDs to ensure at least 8 characters
-	userName := "test_user"
-
 	inputs := map[string]any{
 		"master_username": userName,
 		"master_password": password,
-		"name":            fmt.Sprintf("%s-docdb", name),
+		"name":            fmt.Sprintf("%s-docdb", suffix),
 	}
 
 	defer s.DestroyAtmosComponent(s.T(), component, stack, &inputs)
@@ -91,14 +93,10 @@ func (s *ComponentSuite) TestEnabledFlag() {
 	const stack = "default-test"
 	const awsRegion = "us-east-2"
 
-	name := strings.ToLower(random.UniqueId())
-	password := random.UniqueId() + random.UniqueId()[:4] // Combine two IDs to ensure at least 8 characters
-	userName := "test_user"
-
 	inputs := map[string]any{
 		"master_username": userName,
 		"master_password": password,
-		"name":            fmt.Sprintf("%s-docdb", name),
+		"name":            fmt.Sprintf("%s-docdb", suffix),
 	}
 
 	s.VerifyEnabledFlag(component, stack, &inputs)


### PR DESCRIPTION
## what and why

> [!NOTE]
> The module already supports this functionality (we just need to pass the variable)

- Provide the ability to enable performance insights for the DocumentDB cluster
 
## references

- [Performance Insights](https://docs.aws.amazon.com/documentdb/latest/developerguide/performance-insights.html)
- [Terraform Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an option to enable Performance Insights for enhanced database monitoring.
  - Updated the database cluster module to a newer version for improved functionality.
  - Added support for configurable master user password management with improved security handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->