### PR TITLE
fix: allow to set eks component name

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -11,7 +11,7 @@ module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "eks"
+  component = var.eks_component_name
 
   bypass = !var.eks_security_group_ingress_enabled
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -139,3 +139,10 @@ variable "dns_gbl_delegated_environment_name" {
   description = "The name of the environment where global `dns_delegated` is provisioned"
   default     = "gbl"
 }
+
+variable "eks_component_name" {
+  description = "The name of the EKS component"
+  type        = string
+  default     = "eks"
+}
+


### PR DESCRIPTION
## what
* Documentation of stack setup names `eks` component `eks/cluster`
* In this module the name is hardcoded to `eks`
* Allow to pass the variable `eks_component_name ` as it is done in all other components

## why
* Need to deploy this component with default naming `eks/cluster`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to customize the EKS component name via a new public variable (default: "eks"), allowing alignment with environment naming conventions.
  * Backward-compatible: existing setups continue to use "eks" unless overridden.
  * To use, set the variable to your preferred component name in your configuration or workspace variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->