### PR TITLE
feat: add support for AWS-managed master password

### DIFF
--- a/src/ssm.tf
+++ b/src/ssm.tf
@@ -15,7 +15,7 @@ resource "random_password" "master_password" {
   special = false
   upper   = true
   lower   = true
-  number  = true
+  numeric = true
 
   min_special = 0
   min_upper   = 1

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -40,6 +40,16 @@ variable "master_password" {
   description = "(Required unless a snapshot_identifier is provided) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the DocumentDB Naming Constraints"
 }
 
+variable "manage_master_user_password" {
+  type        = bool
+  description = "Whether to manage the master user password using AWS Secrets Manager."
+  default     = null
+  validation {
+    condition     = var.manage_master_user_password == null || var.manage_master_user_password == true
+    error_message = "Error: `manage_master_user_password` must be set to `true` or `null`"
+  }
+}
+
 variable "retention_period" {
   type        = number
   default     = 5

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0, < 6.0.0"
+      version = ">= 5.29.0, < 6.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## what

This updates the module to support AWS-managed master user passwords for DocumentDB clusters, improves password management logic, and updates provider requirements. The most significant changes are grouped below:

**Password Management Enhancements:**

* Added a new variable `manage_master_user_password` to enable AWS Secrets Manager to manage the master user password, with validation to ensure only `true` or `null` are accepted.
* Refactored local password generation logic in `src/main.tf` to handle three cases: AWS-managed password, user-provided password, or module-generated random password.
* Updated the `documentdb_cluster` module configuration to pass the correct values for `master_password` and `manage_master_user_password` based on the new logic.

**Provider and Resource Updates:**

* Updated the AWS provider version constraint to require at least version 5.29.0, ensuring compatibility with the new password management features.
* Fixed a typo in the `random_password` resource by changing the argument from `number` to `numeric` for correct password generation.
## why

- This update introduces the `manage_master_user_password` variable, allowing the module to use AWS Secrets Manager for managing the DocumentDB master user password

## references

- https://github.com/cloudposse/terraform-aws-documentdb-cluster/pull/131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to manage the master user password via AWS Secrets Manager.
  - Automatically generates a secure master password when not managed by Secrets Manager.
- Changes
  - Updated password generation to use a refined numeric character set.
- Chores
  - Raised the minimum required AWS provider version to 5.29.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->